### PR TITLE
Fixed an issue where exporting ONNX models 

### DIFF
--- a/ultralytics/utils/export.py
+++ b/ultralytics/utils/export.py
@@ -43,6 +43,7 @@ def export_onnx(
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic or None,
+        dynamo=False,
     )
 
 


### PR DESCRIPTION
Fixed an issue where exporting ONNX models forced the use of opset >= 18 and ir_version = 10.